### PR TITLE
Ported from AWS SDK to AWS SDK Core

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -2,7 +2,7 @@ require 'net/http'
 require 'facter'
 
 class EC2Facts
-  EC2_METADATA_URL="http://169.254.169.254/latest/meta-data/"
+  EC2_METADATA_URL="http://169.254.169.254/latest/meta-data/" unless Module.const_defined?(:EC2_METADATA_URL)
   attr_reader :http, :uri
 
   def initialize

--- a/lib/facter/iam_roles.rb
+++ b/lib/facter/iam_roles.rb
@@ -2,8 +2,8 @@ require 'net/http'
 require 'facter'
 require 'json'
 
-EC2_METADATA_URL="http://169.254.169.254/latest/meta-data/"
-EC2_IAM_URL = EC2_METADATA_URL + "iam/security-credentials/"
+EC2_METADATA_URL="http://169.254.169.254/latest/meta-data/" unless Module.const_defined?(:EC2_METADATA_URL)
+EC2_IAM_URL = EC2_METADATA_URL + "iam/security-credentials/" unless Module.const_defined?(:EC2_IAM_URL)
 uri = URI.parse(EC2_IAM_URL)
 http = Net::HTTP.new(uri.host, uri.port)
 response = http.request(Net::HTTP::Get.new(uri.request_uri))


### PR DESCRIPTION
Ported from AWS SDK to AWS SDK Core. This removes the dependency on Nokogiri which makes installation significantly quicker. I have also fixed the region handling, removing the hardcoded locations. Also fixed issues with the constants and missing metadata handling.
